### PR TITLE
fix: implement native ComfyUI POST interface payload

### DIFF
--- a/src/code/agent/constants.py
+++ b/src/code/agent/constants.py
@@ -15,6 +15,7 @@ MNT_DIR = os.getenv('MODEL_ASSET_DIR', '/mnt/auto')
 VENV_DIR = os.getenv('VENV_DIR', WORK_DIR + '/venv')
 MODEL_DIR = os.getenv('MODEL_DIR', MNT_DIR + '/models')
 SKIP_SNAPSHOT_LOADING = os.getenv('SKIP_SNAPSHOT_LOADING')
+SKIP_SNAPSHOT_DOWNLOADING = os.getenv('SKIP_SNAPSHOT_DOWNLOADING').lower() == 'true'
 # API函数启动时是否跳过加载NAS中的custom_nodes.zip到实例磁盘，若跳过则可能遇到部分插件在多个实例并发读写NAS中插件目录时的冲突情况
 SKIP_NODES_LOADING = os.getenv('SKIP_NODES_LOADING', '').lower() == 'true'
 SNAPSHOT_DIR = MNT_DIR + '/snapshots'
@@ -36,6 +37,7 @@ COMFYUI_BOOT_CMD = [
     f"{MNT_DIR}/output",
     "--disable-metadata"
 ]
+COMFY_USE_CPU = os.getenv('COMFY_USE_CPU').lower() == 'true'
 SD_DIR = os.getenv('SD_DIR', WORK_DIR + '/stable-diffusion-webui')
 SD_PROCESS_PORT = 7860
 SD_BOOT_CMD = [
@@ -53,6 +55,9 @@ if USE_API_MODE:
     SD_PROCESS_PORT = 7861
 
 if BACKEND_TYPE == TYPE_COMFYUI:
+    if COMFY_USE_CPU:
+        COMFYUI_BOOT_CMD.append("--cpu")
+
     BACKEND_PROCESS_PORT = COMFYUI_PROCESS_PORT
     BOOT_CMD = COMFYUI_BOOT_CMD
 else:

--- a/src/code/agent/routes/serverless_api_routes.py
+++ b/src/code/agent/routes/serverless_api_routes.py
@@ -72,7 +72,7 @@ class ServerlessApiRoutes:
             返回值:
               输出的图片数组
             """
-            body = request.get_json()
+            payload = request.get_json()
             stream = is_true(request.args.get("stream"))
             output_base64 = is_true(request.args.get("output_base64"))
             output_oss = is_true(request.args.get("output_oss"))
@@ -86,7 +86,7 @@ class ServerlessApiRoutes:
             if not stream:
                 try:
                     return self.service.run(
-                        body,
+                        payload,
                         output_base64=output_base64,
                         output_oss=output_oss,
                         task_id=task_id,
@@ -129,7 +129,7 @@ class ServerlessApiRoutes:
                     """
                     try:
                         result = self.service.run(
-                            body,
+                            payload,
                             output_base64=output_base64,
                             output_oss=output_oss,
                             callback=do_streaming,
@@ -188,15 +188,15 @@ class ServerlessApiRoutes:
                     ),
                 )
 
-                # 获取第一个 message 作为输入的 prompt
+                # 获取第一个 message 作为输入有效载荷 payload
                 data = ws.receive()
-                prompt = json.loads(data)
+                payload = json.loads(data)
 
                 def callback(msg):
                     ws.send(msg)
 
                 results = self.service.run(
-                    prompt,
+                    payload,
                     output_base64=output_base64,
                     output_oss=output_oss,
                     callback=callback,

--- a/src/code/agent/services/serverlessapi/serverless_api_service.py
+++ b/src/code/agent/services/serverlessapi/serverless_api_service.py
@@ -91,11 +91,11 @@ class ServerlessApiService:
             constants.OSS_EXPIRES_IN_SECOND,
         )
 
-    def api_prompt(self, client_id: str, prompt: Any):
+    def api_prompt(self, client_id: str, payload: Any):
         """
         出图
         """
-        req = {"client_id": client_id, "prompt": prompt}
+        req = {"client_id": client_id, **payload}
         res = requests.post(
             os.path.join(self.endpoint, "prompt"),
             json=req,
@@ -325,7 +325,7 @@ class ServerlessApiService:
 
     def run(
         self,
-        prompt: map,
+        payload: map,
         output_base64=False,
         output_oss=False,
         callback=None,
@@ -338,7 +338,7 @@ class ServerlessApiService:
         try:
 
             # 解析请求中是否存在 base64、http url 形式的图片
-            prompt = self.parse_prompt(prompt)
+            payload["prompt"] = self.parse_prompt(payload.get("prompt", {}))
 
             client_id = ""
             prompt_id = ""
@@ -395,7 +395,7 @@ class ServerlessApiService:
             while client_id == "":
                 time.sleep(0.1)
 
-            prompt_result = self.api_prompt(client_id, prompt)
+            prompt_result = self.api_prompt(client_id, payload)
             prompt_id = prompt_result.get("prompt_id", "")
 
             # 如果 task id 未指定，则使用 prompt id

--- a/src/code/agent/services/workspace/snapshot_loader.py
+++ b/src/code/agent/services/workspace/snapshot_loader.py
@@ -26,7 +26,7 @@ class SnapshotLoader(ABC):
 
         service.sub_status = StartingSubStatus.EXTRACTING.value
         with self.timer("Extracting snapshot") as t_extract:
-            self._extract()
+            self._extract(snapshot_path)
         stage_cost["time_extract"] = round(t_extract.elapsed, 2)
 
         self._create_symlinks(snapshot_path)
@@ -47,7 +47,7 @@ class SnapshotLoader(ABC):
         pass
 
     @abstractmethod
-    def _extract(self):
+    def _extract(self, snapshot_path: str):
         """解压依赖"""
         pass
 
@@ -69,7 +69,7 @@ class ComfyUIDevSnapshotLoader(SnapshotLoader):
         if os.path.exists(cache_path):
             file_ops.copy(cache_path, f"{constants.WORK_DIR}/.cache.zip")
 
-    def _extract(self):
+    def _extract(self, snapshot_path: str):
         file_ops.extract(f"{constants.WORK_DIR}/venv.tar")
         file_ops.remove(f"{constants.WORK_DIR}/venv.tar")
         file_ops.extract(f"{constants.WORK_DIR}/comfyui.zip")
@@ -98,6 +98,9 @@ class ComfyUIProdSnapshotLoader(SnapshotLoader):
         file_ops.remove(constants.VENV_DIR)
 
     def _download(self, snapshot_path: str):
+        if constants.SKIP_SNAPSHOT_DOWNLOADING: 
+            return
+        
         file_ops.copy(f"{snapshot_path}/venv.tar", f"{constants.WORK_DIR}/venv.tar")
         file_ops.copy(f"{snapshot_path}/comfyui.zip", f"{constants.WORK_DIR}/comfyui.zip")
         cache_path = f"{snapshot_path}/.cache.zip"
@@ -106,19 +109,31 @@ class ComfyUIProdSnapshotLoader(SnapshotLoader):
         if not constants.SKIP_NODES_LOADING:
             file_ops.copy(f"{snapshot_path}/custom_nodes.zip", f"{constants.WORK_DIR}/custom_nodes.zip")
 
-    def _extract(self):
-        file_ops.extract(f"{constants.WORK_DIR}/venv.tar")
-        file_ops.remove(f"{constants.WORK_DIR}/venv.tar")
-        file_ops.extract(f"{constants.WORK_DIR}/comfyui.zip")
-        file_ops.remove(f"{constants.WORK_DIR}/comfyui.zip")
-        cache_path = f"{constants.WORK_DIR}/.cache.zip"
-        if os.path.exists(cache_path):
-            file_ops.extract(cache_path)
-            file_ops.remove(cache_path)
-        if not constants.SKIP_NODES_LOADING:
-            file_ops.remove(f"{constants.COMFYUI_DIR}/custom_nodes")  # 解压时不会强制覆盖，需手动删除解压时会产生冲突的文件
-            file_ops.extract(f"{constants.WORK_DIR}/custom_nodes.zip", output_dir=f"{constants.COMFYUI_DIR}/custom_nodes")
-            file_ops.remove(f"{constants.WORK_DIR}/custom_nodes.zip")
+    def _extract(self, snapshot_path: str):
+        if constants.SKIP_SNAPSHOT_DOWNLOADING: 
+            file_ops.extract(f"{snapshot_path}/venv.tar", output_dir=f"{constants.WORK_DIR}")
+            file_ops.extract(f"{snapshot_path}/comfyui.zip", output_dir=f"{constants.WORK_DIR}")
+
+            cache_path = f"{snapshot_path}/.cache.zip"
+            if os.path.exists(cache_path):
+                file_ops.extract(cache_path, output_dir=f"{constants.WORK_DIR}/.cache")
+
+            if not constants.SKIP_NODES_LOADING:
+                file_ops.remove(f"{constants.COMFYUI_DIR}/custom_nodes")
+                file_ops.extract(f"{snapshot_path}/custom_nodes.zip", output_dir=f"{constants.COMFYUI_DIR}/custom_nodes")
+        else:
+            file_ops.extract(f"{constants.WORK_DIR}/venv.tar")
+            file_ops.remove(f"{constants.WORK_DIR}/venv.tar")
+            file_ops.extract(f"{constants.WORK_DIR}/comfyui.zip")
+            file_ops.remove(f"{constants.WORK_DIR}/comfyui.zip")
+            cache_path = f"{constants.WORK_DIR}/.cache.zip"
+            if os.path.exists(cache_path):
+                file_ops.extract(cache_path)
+                file_ops.remove(cache_path)
+            if not constants.SKIP_NODES_LOADING:
+                file_ops.remove(f"{constants.COMFYUI_DIR}/custom_nodes")  # 解压时不会强制覆盖，需手动删除解压时会产生冲突的文件
+                file_ops.extract(f"{constants.WORK_DIR}/custom_nodes.zip", output_dir=f"{constants.COMFYUI_DIR}/custom_nodes")
+                file_ops.remove(f"{constants.WORK_DIR}/custom_nodes.zip")
 
     def _create_symlinks(self, snapshot_path: str):
         file_ops.create_symlink(
@@ -147,7 +162,7 @@ class SDSnapshotLoader(SnapshotLoader):
         if os.path.exists(cache_path):
             file_ops.copy(cache_path, f"{constants.WORK_DIR}/.cache.zip")
 
-    def _extract(self):
+    def _extract(self, snapshot_path: str):
         file_ops.extract(f"{constants.WORK_DIR}/venv.tar")
         file_ops.remove(f"{constants.WORK_DIR}/venv.tar")
         file_ops.extract(f"{constants.WORK_DIR}/stable-diffusion-webui.zip")


### PR DESCRIPTION
The latest version of ComfyUI (see: https://github.com/comfyanonymous/ComfyUI/releases/tag/v0.3.57) supports calling external closed-source model APIs. In my project, I used Google's Gemini 2.5 Flash model, but invoking closed-source models requires logging into a ComfyUI account and using account credits for payment.

The latest ComfyUI version supports attaching an extra_data parameter when submitting a prompt to include api_key_comfy_org (see: https://docs.comfy.org/development/comfyui-server/api-key-integration#python-example).

The current agent implementation only passes client-submitted data as the prompt, unable to include a valid extra_data parameter. Therefore, following the native ComfyUI /prompt interface, the entire client-submitted data is passed as the payload to ComfyUI for processing.

**Warning: This change will alter the parameter structure of the existing interface, potentially causing business functionality to break!**