### PR TITLE
feat: 修复因input目录中图片数量过多导致的LoadImage节点执行时间增长的问题

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,33 +7,27 @@ $(error Invalid REGION: $(REGION). Must be one of: $(VALID_REGIONS))
 endif
 
 VERSION ?= $(shell date "+%Y%m%d%H%M%S")
-AGENT_IMAGE = registry.$(REGION).aliyuncs.com/ohyee/fc-demo:agent-$(VERSION)
+AGENT_IMAGE = cap-demo-public-registry.cn-hangzhou.cr.aliyuncs.com/cap-app/image-generation-comfyui-agent-dev:$(VERSION)
 export OSS_BUCKET = dipper-cache-$(REGION)
 
-# 构建并推送Agent镜像到所有Region
+# 构建并推送Agent镜像
 # make all
 # CR_PWD=xxx make all
-# REGIONS="cn-hangzhou cn-shanghai" CR_PWD=xxx make all
-# CR_PWD=xxx VERSION=v0.0.1-alpha.0 make all
+# CR_USER=xxx CR_PWD=xxx make all
+# CR_PWD=xxx VERSION=v1.0.0 make all
 .PHONY: all
 all:
-	@REGIONS_TO_DEPLOY="$${REGIONS:-$(VALID_REGIONS)}"; \
-	echo "====== Will process regions: $$REGIONS_TO_DEPLOY ======"; \
-	for region in $$REGIONS_TO_DEPLOY; do \
-		if ! echo "$(VALID_REGIONS)" | grep -w "$$region" > /dev/null; then \
-			echo "Error: Invalid region '$$region'. Must be one of: $(VALID_REGIONS)"; \
-			exit 1; \
-		fi; \
-	done; \
-	for region in $$REGIONS_TO_DEPLOY; do \
-		echo "\n====== Processing region: $$region ======"; \
-		$(MAKE) REGION=$$region CR_PWD="$$CR_PWD" VERSION=$(VERSION) login build push; \
-		if [ $$? -ne 0 ]; then \
-			echo "====== Failed in region $$region ======"; \
-			exit 1; \
-		fi; \
-		echo "====== Completed region: $$region ======"; \
-	done
+	@echo "====== Building and pushing agent image ======"; \
+	BUILD_VERSION=$${VERSION:-$$(date "+%Y%m%d%H%M%S")}; \
+	$(MAKE) VERSION=$$BUILD_VERSION login && \
+	$(MAKE) VERSION=$$BUILD_VERSION build && \
+	$(MAKE) VERSION=$$BUILD_VERSION push; \
+	if [ $$? -eq 0 ]; then \
+		echo "====== Build and push completed successfully ======"; \
+	else \
+		echo "====== Build and push failed ======"; \
+		exit 1; \
+	fi
 
 # 构建Agent镜像
 .PHONY: build
@@ -49,18 +43,19 @@ run:
 # 本地测试登录
 .PHONY: exec
 exec:
-	docker run -it --rm -p 9000:9000 --entrypoint /bin/bash $(IMAGE_NAME):$(TAG)
+	docker run -it --rm -p 9000:9000 --entrypoint /bin/bash agent
 
 # 登录镜像仓库
-# REGION=xxx CR_PWD=xxx make login
+# CR_USER=xxx CR_PWD=xxx make login
 .PHONY: login
 login:
 	@if [ -z "$$CR_PWD" ]; then \
-		echo "[$(REGION)] No CR_PWD provided, using interactive login..."; \
-		docker login --username=oyohyee@gmail.com registry.$(REGION).aliyuncs.com; \
+		echo "No CR_PWD provided, using interactive login..."; \
+		docker login cap-demo-public-registry.cn-hangzhou.cr.aliyuncs.com; \
 	else \
-		echo "[$(REGION)] Using provided CR_PWD for login..."; \
-		echo "$$CR_PWD" | docker login --username=oyohyee@gmail.com --password-stdin registry.$(REGION).aliyuncs.com; \
+		echo "Using provided credentials for login..."; \
+		CR_USER=$${CR_USER:-oyohyee@gmail.com}; \
+		echo "$$CR_PWD" | docker login --username=$$CR_USER --password-stdin cap-demo-public-registry.cn-hangzhou.cr.aliyuncs.com; \
 	fi
 
 # 推送镜像

--- a/src/code/agent/constants.py
+++ b/src/code/agent/constants.py
@@ -26,43 +26,50 @@ SNAPSHOT_PATTERN = '%Y%m%d-%H%M%S'
 COMFYUI_DIR = os.getenv('COMFYUI_DIR', WORK_DIR + '/comfyui')
 COMFYUI_PROCESS_PORT = 8188
 
-# CPU模式启动命令
-COMFYUI_CPU_BOOT_CMD = [
-    f"{VENV_DIR}/bin/python",
-    f"{COMFYUI_DIR}/main.py",
-    "--cpu",
-    "--listen",
-    "0.0.0.0",
-    "--input-directory",
-    f"{MNT_DIR}/input",
-    "--output-directory",
-    f"{MNT_DIR}/output",
-    "--temp-directory",
-    f"{MNT_DIR}/output",
-    "--user-directory",
-    f"{MNT_DIR}/output",
-    "--disable-metadata"
-]
+# 共享存储中的输入目录（NAS 中的 input 目录），issue: https://aliyuque.antfin.com/lnpq52/cc8sut/slcnbzw0t7q9snbb
+MNT_INPUT_DIR = os.getenv('MNT_INPUT_DIR', f"{MNT_DIR}/input")
 
-# GPU模式启动命令（不包含--cpu参数）
-COMFYUI_GPU_BOOT_CMD = [
-    f"{VENV_DIR}/bin/python",
-    f"{COMFYUI_DIR}/main.py",
-    "--listen",
-    "0.0.0.0",
-    "--input-directory",
-    f"{MNT_DIR}/input",
-    "--output-directory",
-    f"{MNT_DIR}/output",
-    "--temp-directory",
-    f"{MNT_DIR}/output",
-    "--user-directory",
-    f"{MNT_DIR}/output",
-    "--disable-metadata"
-]
-
-# 根据模式选择启动命令
-COMFYUI_BOOT_CMD = COMFYUI_CPU_BOOT_CMD if COMFYUI_MODE == 'cpu' else COMFYUI_GPU_BOOT_CMD
+# 根据 COMFYUI_MODE 配置输入目录和启动命令
+if COMFYUI_MODE == 'cpu':
+    # CPU模式：输入目录默认使用 MNT_INPUT_DIR
+    INPUT_DIR = os.getenv('INPUT_DIR', MNT_INPUT_DIR)
+    COMFYUI_BOOT_CMD = [
+        f"{VENV_DIR}/bin/python",
+        f"{COMFYUI_DIR}/main.py",
+        "--cpu",
+        "--listen",
+        "0.0.0.0",
+        "--input-directory",
+        INPUT_DIR,
+        "--output-directory",
+        f"{MNT_DIR}/output",
+        "--temp-directory",
+        f"{MNT_DIR}/output",
+        "--user-directory",
+        f"{MNT_DIR}/output",
+        "--disable-metadata"
+    ]
+else:
+    # GPU模式：线上服务输入目录默认使用 COMFYUI_DIR/input(实例磁盘)，项目开发默认使用 MNT_INPUT_DIR
+    if USE_API_MODE:
+        INPUT_DIR = os.getenv('INPUT_DIR', f"{COMFYUI_DIR}/input")
+    else:
+        INPUT_DIR = os.getenv('INPUT_DIR', MNT_INPUT_DIR)
+    COMFYUI_BOOT_CMD = [
+        f"{VENV_DIR}/bin/python",
+        f"{COMFYUI_DIR}/main.py",
+        "--listen",
+        "0.0.0.0",
+        "--input-directory",
+        INPUT_DIR,
+        "--output-directory",
+        f"{MNT_DIR}/output",
+        "--temp-directory",
+        f"{MNT_DIR}/output",
+        "--user-directory",
+        f"{MNT_DIR}/output",
+        "--disable-metadata"
+    ]
 SD_DIR = os.getenv('SD_DIR', WORK_DIR + '/stable-diffusion-webui')
 SD_PROCESS_PORT = 7860
 SD_BOOT_CMD = [

--- a/src/code/agent/services/serverlessapi/input_cleaner.py
+++ b/src/code/agent/services/serverlessapi/input_cleaner.py
@@ -1,0 +1,230 @@
+"""
+Input 目录清理模块
+
+用于清理 ComfyUI input 目录中的过期临时文件（自动上传的图片/音频/视频）。
+适用于 Serverless 架构，支持 CPU freeze/unfreeze 场景。
+
+仅在 API 模式且 INPUT_DIR 使用实例磁盘（非 MNT_INPUT_DIR）时启用。
+
+使用方式:
+    from services.serverlessapi.input_cleaner import wake
+    wake()  # 在请求中调用，唤醒清理线程（如果清理器未启用则无操作）
+"""
+
+import os
+import time
+import threading
+from typing import Optional
+
+import constants
+from utils.logger import log
+
+
+class InputCleaner:
+    """
+    Input 目录清理器（Event 唤醒模式）
+    
+    后台线程大部分时间休眠，由请求唤醒执行清理。
+    多个并发请求的唤醒信号会合并为一次。
+    
+    特性:
+    - 惰性清理：后台线程休眠，由请求唤醒
+    - 线程安全：多个并发唤醒信号合并为一次
+    - Serverless 友好：无请求时不执行任何操作
+    """
+    
+    def __init__(
+        self,
+        input_dir: Optional[str] = None,
+        cleanup_interval: Optional[int] = None,
+        file_ttl: Optional[int] = None,
+    ):
+        """
+        初始化清理器
+        
+        Args:
+            input_dir: 要清理的目录，默认使用 constants.INPUT_DIR
+            cleanup_interval: 清理间隔（秒），默认 3600（1小时）
+            file_ttl: 文件过期时间（秒），默认 21600（6小时）
+            min_files_threshold: 最小文件数阈值，低于此数量不清理，默认 1000
+        """
+        self._input_dir = input_dir or constants.INPUT_DIR
+        self._cleanup_interval = cleanup_interval or int(os.getenv("INPUT_CLEANUP_INTERVAL", "3600"))  # 默认1小时
+        self._file_ttl = file_ttl or int(os.getenv("INPUT_FILE_TTL", "21600"))  # 默认6小时
+        self._min_files_threshold = int(os.getenv("INPUT_CLEANUP_MIN_FILES", "1000"))  # 默认1000个文件
+        
+        self._last_cleanup_time = 0
+        self._wake_event = threading.Event()  # 唤醒信号
+        self._stop_event = threading.Event()  # 停止信号
+        
+        # 启动后台清理线程
+        self._thread = threading.Thread(target=self._cleanup_loop, daemon=True)
+        self._thread.start()
+        
+        log("DEBUG", f"InputCleaner initialized: dir={self._input_dir}, interval={self._cleanup_interval}s, ttl={self._file_ttl}s, min_files={self._min_files_threshold}")
+    
+    def wake(self):
+        """
+        唤醒清理线程（请求时调用）
+        
+        多个并发请求调用 wake() 只会触发一次清理。
+        如果距离上次清理时间不足 cleanup_interval，清理线程会忽略本次唤醒。
+        """
+        self._wake_event.set()
+    
+    def _cleanup_loop(self):
+        """后台清理线程主循环"""
+        while not self._stop_event.is_set():
+            # 等待唤醒信号（Serverless 架构下无请求时实例会 freeze，无需超时兜底）
+            self._wake_event.wait()
+            
+            # 清除唤醒信号（为下次唤醒做准备）
+            self._wake_event.clear()
+            
+            # 检查是否需要停止
+            if self._stop_event.is_set():
+                break
+            
+            # 检查距离上次清理是否足够长
+            now = time.time()
+            if now - self._last_cleanup_time < self._cleanup_interval:
+                log("DEBUG", "InputCleaner: awakened but skipped (too soon since last cleanup)")
+                continue
+            
+            # 执行清理
+            self._last_cleanup_time = now
+            try:
+                start_time = time.time()
+                cleaned = self._cleanup_old_files()
+                elapsed = time.time() - start_time
+                if cleaned > 0:
+                    log("INFO", f"InputCleaner: async cleanup completed, removed {cleaned} files from {self._input_dir} in {elapsed:.2f}s")
+            except Exception as e:
+                log("WARNING", f"InputCleaner: async cleanup failed: {e}")
+    
+    def stop(self):
+        """停止清理线程"""
+        self._stop_event.set()
+        self._wake_event.set()  # 唤醒线程以便它能检查停止信号
+        self._thread.join(timeout=5)
+    
+    def cleanup_sync(self) -> int:
+        """
+        同步执行清理（阻塞当前线程）
+        
+        Returns:
+            int: 清理的文件数量
+        """
+        return self._cleanup_old_files()
+    
+    def _cleanup_old_files(self) -> int:
+        """
+        清理过期文件
+        
+        使用 os.scandir() 高效遍历目录，删除超过 TTL 的文件。
+        注意：只清理目录下的一级文件，不会递归清理子目录。
+        当文件数量低于 min_files_threshold 时跳过清理。
+        
+        Returns:
+            int: 清理的文件数量
+        """
+        log("DEBUG", f"InputCleaner: starting cleanup scan on {self._input_dir}")
+        
+        if not os.path.exists(self._input_dir):
+            return 0
+        
+        # 先统计文件数量，低于阈值则跳过清理
+        try:
+            file_count = sum(1 for entry in os.scandir(self._input_dir) if entry.is_file())
+            if file_count < self._min_files_threshold:
+                log("DEBUG", f"InputCleaner: skipped cleanup, file count ({file_count}) below threshold ({self._min_files_threshold})")
+                return 0
+        except Exception as e:
+            log("WARNING", f"InputCleaner: failed to count files: {e}")
+            return 0
+        
+        now = time.time()
+        cleaned = 0
+        
+        try:
+            with os.scandir(self._input_dir) as entries:
+                for entry in entries:
+                    try:
+                        # entry.is_file() 和 entry.stat() 使用缓存的 stat 结果
+                        if entry.is_file():
+                            file_age = now - entry.stat().st_mtime
+                            if file_age > self._file_ttl:
+                                os.remove(entry.path)
+                                cleaned += 1
+                    except FileNotFoundError:
+                        # 文件可能被其他进程删除，忽略
+                        pass
+                    except Exception as e:
+                        log("DEBUG", f"InputCleaner: failed to process {entry.name}: {e}")
+        except Exception as e:
+            log("WARNING", f"InputCleaner: failed to scan directory {self._input_dir}: {e}")
+        
+        return cleaned
+    
+    @property
+    def is_running(self) -> bool:
+        """检查清理线程是否在运行"""
+        return self._thread.is_alive()
+    
+    @property
+    def input_dir(self) -> str:
+        """获取清理目录路径"""
+        return self._input_dir
+    
+    @property
+    def file_ttl(self) -> int:
+        """获取文件过期时间（秒）"""
+        return self._file_ttl
+    
+    @property
+    def cleanup_interval(self) -> int:
+        """获取清理间隔（秒）"""
+        return self._cleanup_interval
+
+
+# ============================================================================
+# 模块级单例和便捷函数
+# ============================================================================
+
+# 全局清理器实例（仅在满足条件时初始化）
+_cleaner_instance: Optional[InputCleaner] = None
+
+
+def _should_enable_cleaner() -> bool:
+    """判断是否应该启用清理器"""
+    # 仅在 API 模式且 INPUT_DIR 使用实例磁盘（非共享存储）时启用
+    return constants.USE_API_MODE and constants.INPUT_DIR != constants.MNT_INPUT_DIR
+
+
+def _init_cleaner():
+    """初始化全局清理器实例"""
+    global _cleaner_instance
+    if _cleaner_instance is None and _should_enable_cleaner():
+        _cleaner_instance = InputCleaner()
+        log("INFO", f"InputCleaner enabled: INPUT_DIR={constants.INPUT_DIR}")
+    elif not _should_enable_cleaner():
+        log("DEBUG", f"InputCleaner disabled: USE_API_MODE={constants.USE_API_MODE}, INPUT_DIR={constants.INPUT_DIR}, MNT_INPUT_DIR={constants.MNT_INPUT_DIR}")
+
+
+def wake():
+    """
+    唤醒清理线程（便捷函数）
+    
+    如果清理器未启用，则不执行任何操作。
+    """
+    if _cleaner_instance is not None:
+        _cleaner_instance.wake()
+
+
+def get_cleaner() -> Optional[InputCleaner]:
+    """获取全局清理器实例（可能为 None）"""
+    return _cleaner_instance
+
+
+# 模块加载时自动初始化
+_init_cleaner()

--- a/src/code/agent/services/serverlessapi/serverless_api_service.py
+++ b/src/code/agent/services/serverlessapi/serverless_api_service.py
@@ -18,6 +18,7 @@ from utils import file_ops
 
 from uuid import uuid4, UUID
 from flask import request
+from services.serverlessapi.input_cleaner import wake as wake_input_cleaner
 
 
 class ComfyUIException(Exception):
@@ -184,35 +185,34 @@ class ServerlessApiService:
 
         return ws
 
-    def api_upload_image(self, content: bytes, overwrite: bool):
+    def api_upload_image(self, content: bytes):
         """
-        上传图片到 ComfyUI
+        上传图片到 ComfyUI 的 input 目录
         
-        将图片内容上传到 ComfyUI 的 input 目录，供工作流节点使用。
+        直接将图片写入 INPUT_DIR; 
+        文件名基于内容 MD5 生成，相同内容产生相同文件名。
+        如果文件已存在（内容相同），仅更新 mtime 而不重写内容。
         
         Args:
             content: 图片二进制内容
-            overwrite: 是否覆盖同名文件
             
         Returns:
-            dict: 包含上传后的文件信息（如 name 字段）
+            dict: 包含上传后的文件信息，格式 {"name": "filename"}
         """
-        # 基于内容生成确定性的 UUID，相同内容产生相同 UUID
+        # 基于内容生成确定性的文件名，相同内容产生相同文件名
         content_hash = hashlib.md5(content).hexdigest()
-        uuid = str(UUID(content_hash))
-        files = {
-            "image": (uuid, content),
-        }
-
-        if overwrite:
-            files["overwrite"] = bytes("1")
-
-        res = requests.post(
-            os.path.join(self.endpoint, "upload/image"),
-            files=files,
-        )
-
-        return res.json()
+        filename = str(UUID(content_hash))
+        filepath = os.path.join(constants.INPUT_DIR, filename)
+        
+        if os.path.exists(filepath):
+            # 文件已存在（内容相同），仅更新 mtime，防止被清理
+            os.utime(filepath, None)
+        else:
+            # 文件不存在，写入内容
+            with open(filepath, 'wb') as f:
+                f.write(content)
+        
+        return {"name": filename}
 
     def api_get_history(self, prompt_id: str):
         """
@@ -344,27 +344,25 @@ class ServerlessApiService:
                             pass
                     
                     else:
-                        # 使用文件名
+                        # 文件来源于共享存储（NAS），利用api_upload_image拷贝到实例磁盘
+                        # issue: https://aliyuque.antfin.com/lnpq52/cc8sut/slcnbzw0t7q9snbb
                         input_dir = constants.INPUT_DIR
                         file_path = os.path.join(input_dir, file_url)
                         mnt_input_dir = constants.MNT_INPUT_DIR
                         mnt_file_path = os.path.join(mnt_input_dir, file_url)
-                        
-                        # 若 input_dir 不在挂载的共享存储中(在实例磁盘)，则需要尝试从共享存储中查找同名文件
-                        # issue: https://aliyuque.antfin.com/lnpq52/cc8sut/slcnbzw0t7q9snbb
-                        if  input_dir != mnt_input_dir and not os.path.exists(file_path) and os.path.exists(mnt_file_path):
-                            log("DEBUG", f"copying {file_type}: {mnt_file_path} -> {file_path}")
+                        if input_dir != mnt_input_dir and not os.path.exists(file_path) and os.path.exists(mnt_file_path):
+                            log("DEBUG", f"reading {file_type} from MNT: {mnt_file_path}")
                             start_time = time.perf_counter()
-                            file_ops.copy(mnt_file_path, file_path)
+                            with open(mnt_file_path, 'rb') as f:
+                                content = f.read()
                             elapsed = time.perf_counter() - start_time
-                            file_size = os.path.getsize(file_path)
-                            log("DEBUG", f"successfully copied {file_type}: {file_url} ({file_size} bytes) in {elapsed:.2f}s")
+                            log("DEBUG", f"successfully read {file_type}: {file_url} ({len(content)} bytes) in {elapsed:.2f}s")
                             
                     if content:
                         # 上传文件并更新对应的输入字段
                         log("DEBUG", f"uploading {file_type} to ComfyUI")
                         start_time = time.perf_counter()
-                        res = self.api_upload_image(content, False)
+                        res = self.api_upload_image(content)
                         elapsed = time.perf_counter() - start_time
                         log("INFO", f"successfully uploaded {file_type} to ComfyUI as '{res['name']}' in {elapsed:.2f}s")
                         prompt[key]["inputs"][input_key] = res["name"]
@@ -606,9 +604,11 @@ class ServerlessApiService:
         """
 
         try:
-
             # 解析请求中是否存在 base64、http url 形式的图片
             prompt = self.parse_prompt(prompt)
+
+            # 唤醒 input 目录清理线程（在 parse_prompt 之后，确保上传的文件 mtime 已更新，防止清理ttl到期的同名文件）
+            wake_input_cleaner()
 
             client_id = ""
             prompt_id = ""

--- a/src/code/agent/services/serverlessapi/serverless_api_service.py
+++ b/src/code/agent/services/serverlessapi/serverless_api_service.py
@@ -14,6 +14,7 @@ from typing import Any
 import constants
 from store import Store, FileSystem, OSS
 from utils.logger import log
+from utils import file_ops
 
 from uuid import uuid4, UUID
 from flask import request
@@ -90,13 +91,13 @@ class ServerlessApiService:
 
         # 如果 header 没有，尝试从 env 获取
         if ak == "" or sk == "":
-            log("WARNING", "failed to get credentials from header")
+            log("DEBUG", "failed to get credentials from header")
 
             ak = constants.ALIBABA_CLOUD_ACCESS_KEY_ID
             sk = constants.ALIBABA_CLOUD_ACCESS_KEY_SECRET
             sts = constants.ALIBABA_CLOUD_SECURITY_TOKEN
         if ak == "" or sk == "":
-            log("WARNING", "failed to get credentials from env")
+            log("DEBUG", "failed to get credentials from env")
         return ak, sk, sts
 
     def get_oss_store(self):
@@ -341,6 +342,23 @@ class ServerlessApiService:
                             elapsed = time.perf_counter() - start_time
                             log("DEBUG", f"failed to decode {file_type} from Base64 in {elapsed:.2f}s")
                             pass
+                    
+                    else:
+                        # 使用文件名
+                        input_dir = constants.INPUT_DIR
+                        file_path = os.path.join(input_dir, file_url)
+                        mnt_input_dir = constants.MNT_INPUT_DIR
+                        mnt_file_path = os.path.join(mnt_input_dir, file_url)
+                        
+                        # 若 input_dir 不在挂载的共享存储中(在实例磁盘)，则需要尝试从共享存储中查找同名文件
+                        # issue: https://aliyuque.antfin.com/lnpq52/cc8sut/slcnbzw0t7q9snbb
+                        if  input_dir != mnt_input_dir and not os.path.exists(file_path) and os.path.exists(mnt_file_path):
+                            log("DEBUG", f"copying {file_type}: {mnt_file_path} -> {file_path}")
+                            start_time = time.perf_counter()
+                            file_ops.copy(mnt_file_path, file_path)
+                            elapsed = time.perf_counter() - start_time
+                            file_size = os.path.getsize(file_path)
+                            log("DEBUG", f"successfully copied {file_type}: {file_url} ({file_size} bytes) in {elapsed:.2f}s")
                             
                     if content:
                         # 上传文件并更新对应的输入字段

--- a/src/code/agent/services/workspace/snapshot_loader.py
+++ b/src/code/agent/services/workspace/snapshot_loader.py
@@ -189,6 +189,9 @@ class ComfyUIProdSnapshotLoader(SnapshotLoader):
                 link_path=f"{constants.COMFYUI_DIR}/custom_nodes",
                 force=True
             )
+        # 线上服务GPU实例使用实例磁盘中的input目录，需确保目录存在防止comfyui启动过程中LoadImage节点加载失败
+        if not os.path.exists(constants.INPUT_DIR):
+            os.makedirs(constants.INPUT_DIR, exist_ok=True)
 
 
 class SDSnapshotLoader(SnapshotLoader):

--- a/src/code/agent/store/oss.py
+++ b/src/code/agent/store/oss.py
@@ -38,7 +38,7 @@ class OSS:
             and arr[2] == "aliyuncs"
             and arr[3] == "com"
         ):
-            log("ERROR", f"OSS endpoint '{self.oss_endpoint}' is invalid (expected format: bucket.oss-region.aliyuncs.com)")
+            log("DEBUG", f"OSS endpoint '{self.oss_endpoint}' is invalid (expected format: bucket.oss-region.aliyuncs.com)")
             return
 
         self.bucket_name = arr[0].split("/")[-1] if "/" in arr[0] else arr[0]

--- a/src/code/agent/test/unit/services/input_cleaner_test.py
+++ b/src/code/agent/test/unit/services/input_cleaner_test.py
@@ -1,0 +1,634 @@
+"""
+InputCleaner 单元测试
+
+测试 Input 目录清理器的各种场景：
+- 基本清理功能
+- TTL 过期判断
+- 并发唤醒合并
+- 清理间隔控制
+- 最小文件数阈值
+
+运行方式：
+    cd src/code/agent
+    python -m pytest test/unit/services/input_cleaner_test.py -v
+"""
+
+import os
+import time
+import tempfile
+import threading
+import pytest
+from unittest.mock import patch, MagicMock
+
+from services.serverlessapi.input_cleaner import InputCleaner
+
+
+# ==================== Fixtures ====================
+
+@pytest.fixture
+def temp_input_dir():
+    """创建临时目录用于测试"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield tmpdir
+
+
+@pytest.fixture
+def cleaner(temp_input_dir):
+    """
+    创建测试用的 InputCleaner 实例
+    
+    使用很短的 TTL 和 interval 以便快速测试
+    min_files_threshold=0 禁用阈值检查，确保基本测试正常运行
+    """
+    with patch.dict(os.environ, {"INPUT_CLEANUP_MIN_FILES": "0"}):
+        cleaner = InputCleaner(
+            input_dir=temp_input_dir,
+            cleanup_interval=1,  # 1秒清理间隔
+            file_ttl=2,  # 2秒过期
+        )
+        yield cleaner
+        cleaner.stop()
+
+
+@pytest.fixture
+def cleaner_no_auto_start(temp_input_dir):
+    """
+    创建不自动启动线程的 InputCleaner（用于同步测试）
+    
+    通过直接调用 cleanup_sync() 进行测试
+    min_files_threshold=0 禁用阈值检查
+    """
+    # 暂时 mock 线程启动
+    with patch.object(InputCleaner, '_cleanup_loop'):
+        with patch.dict(os.environ, {"INPUT_CLEANUP_MIN_FILES": "0"}):
+            cleaner = InputCleaner(
+                input_dir=temp_input_dir,
+                cleanup_interval=1,
+                file_ttl=2,
+            )
+            yield cleaner
+
+
+def create_test_file(directory: str, filename: str, age_seconds: float = 0) -> str:
+    """
+    创建测试文件
+    
+    Args:
+        directory: 目录路径
+        filename: 文件名
+        age_seconds: 文件年龄（秒），通过修改 mtime 实现
+        
+    Returns:
+        str: 文件完整路径
+    """
+    filepath = os.path.join(directory, filename)
+    with open(filepath, 'w') as f:
+        f.write(f"test content for {filename}")
+    
+    if age_seconds > 0:
+        # 修改文件的修改时间，使其看起来是 age_seconds 秒前创建的
+        old_time = time.time() - age_seconds
+        os.utime(filepath, (old_time, old_time))
+    
+    return filepath
+
+
+# ==================== 基本功能测试 ====================
+
+class TestBasicCleanup:
+    """测试基本清理功能"""
+    
+    def test_cleanup_expired_files(self, cleaner_no_auto_start, temp_input_dir):
+        """测试清理过期文件"""
+        # 创建一个过期文件（3秒前）和一个新文件
+        old_file = create_test_file(temp_input_dir, "old_image.png", age_seconds=3)
+        new_file = create_test_file(temp_input_dir, "new_image.png", age_seconds=0)
+        
+        # TTL 是 2秒，所以 old_file 应该被清理
+        cleaned = cleaner_no_auto_start.cleanup_sync()
+        
+        assert cleaned == 1
+        assert not os.path.exists(old_file), "过期文件应该被删除"
+        assert os.path.exists(new_file), "新文件不应该被删除"
+    
+    def test_no_cleanup_when_all_files_fresh(self, cleaner_no_auto_start, temp_input_dir):
+        """测试所有文件都是新的时不清理"""
+        create_test_file(temp_input_dir, "file1.png", age_seconds=0)
+        create_test_file(temp_input_dir, "file2.png", age_seconds=1)
+        
+        cleaned = cleaner_no_auto_start.cleanup_sync()
+        
+        assert cleaned == 0
+        assert len(os.listdir(temp_input_dir)) == 2
+    
+    def test_cleanup_all_expired_files(self, cleaner_no_auto_start, temp_input_dir):
+        """测试清理所有过期文件"""
+        # 创建 5 个过期文件
+        for i in range(5):
+            create_test_file(temp_input_dir, f"old_{i}.png", age_seconds=5)
+        
+        cleaned = cleaner_no_auto_start.cleanup_sync()
+        
+        assert cleaned == 5
+        assert len(os.listdir(temp_input_dir)) == 0
+    
+    def test_cleanup_empty_directory(self, cleaner_no_auto_start, temp_input_dir):
+        """测试空目录不报错"""
+        cleaned = cleaner_no_auto_start.cleanup_sync()
+        assert cleaned == 0
+    
+    def test_cleanup_nonexistent_directory(self):
+        """测试不存在的目录不报错"""
+        with patch.object(InputCleaner, '_cleanup_loop'):
+            with patch.dict(os.environ, {"INPUT_CLEANUP_MIN_FILES": "0"}):
+                cleaner = InputCleaner(
+                    input_dir="/nonexistent/path",
+                    cleanup_interval=1,
+                    file_ttl=2,
+                )
+                cleaned = cleaner.cleanup_sync()
+                assert cleaned == 0
+    
+    def test_only_cleanup_files_not_directories(self, cleaner_no_auto_start, temp_input_dir):
+        """测试只清理文件，不清理子目录"""
+        # 创建一个过期文件和一个子目录
+        old_file = create_test_file(temp_input_dir, "old.png", age_seconds=5)
+        subdir = os.path.join(temp_input_dir, "subdir")
+        os.makedirs(subdir)
+        # 在子目录中创建过期文件（不应被清理）
+        create_test_file(subdir, "nested_old.png", age_seconds=5)
+        
+        cleaned = cleaner_no_auto_start.cleanup_sync()
+        
+        assert cleaned == 1
+        assert not os.path.exists(old_file)
+        assert os.path.exists(subdir), "子目录不应被删除"
+        assert os.path.exists(os.path.join(subdir, "nested_old.png")), "子目录中的文件不应被清理"
+
+
+# ==================== 异步清理测试 ====================
+
+class TestAsyncCleanup:
+    """测试异步清理功能"""
+    
+    def test_wake_triggers_cleanup(self, cleaner, temp_input_dir):
+        """测试 wake() 能触发清理"""
+        # 创建过期文件
+        old_file = create_test_file(temp_input_dir, "old.png", age_seconds=5)
+        
+        # 唤醒清理线程
+        cleaner.wake()
+        
+        # 等待清理完成
+        time.sleep(0.5)
+        
+        assert not os.path.exists(old_file), "wake() 应该触发清理"
+    
+    def test_cleanup_interval_respected(self, cleaner, temp_input_dir):
+        """测试清理间隔被遵守"""
+        # 第一次清理
+        old_file1 = create_test_file(temp_input_dir, "old1.png", age_seconds=5)
+        cleaner.wake()
+        time.sleep(0.5)
+        assert not os.path.exists(old_file1)
+        
+        # 立即创建新的过期文件并唤醒
+        old_file2 = create_test_file(temp_input_dir, "old2.png", age_seconds=5)
+        cleaner.wake()
+        time.sleep(0.3)
+        
+        # 因为距离上次清理不足 1 秒（cleanup_interval），不应该清理
+        assert os.path.exists(old_file2), "清理间隔内不应该再次清理"
+        
+        # 等待超过清理间隔后再唤醒
+        time.sleep(1)
+        cleaner.wake()
+        time.sleep(0.5)
+        
+        assert not os.path.exists(old_file2), "超过清理间隔后应该清理"
+    
+    def test_multiple_concurrent_wakes(self, cleaner, temp_input_dir):
+        """测试多个并发唤醒只触发一次清理"""
+        # 创建过期文件
+        create_test_file(temp_input_dir, "old.png", age_seconds=5)
+        
+        # 用一个计数器来跟踪清理次数
+        cleanup_count = [0]
+        original_cleanup = cleaner._cleanup_old_files
+        
+        def counting_cleanup():
+            cleanup_count[0] += 1
+            return original_cleanup()
+        
+        cleaner._cleanup_old_files = counting_cleanup
+        
+        # 并发发送多个唤醒信号
+        threads = []
+        for _ in range(10):
+            t = threading.Thread(target=cleaner.wake)
+            threads.append(t)
+            t.start()
+        
+        for t in threads:
+            t.join()
+        
+        # 等待清理完成
+        time.sleep(0.5)
+        
+        # 应该只清理一次（因为在 cleanup_interval 内）
+        assert cleanup_count[0] == 1, f"并发唤醒应该只触发一次清理，实际 {cleanup_count[0]} 次"
+
+
+# ==================== 边界条件测试 ====================
+
+class TestEdgeCases:
+    """测试边界条件"""
+    
+    def test_file_deleted_during_cleanup(self, cleaner_no_auto_start, temp_input_dir):
+        """测试清理过程中文件被其他进程删除"""
+        old_file = create_test_file(temp_input_dir, "old.png", age_seconds=5)
+        
+        # 在清理前删除文件，模拟并发删除
+        original_remove = os.remove
+        def delayed_remove(path):
+            if "old.png" in path:
+                # 模拟文件已被删除
+                raise FileNotFoundError(f"File not found: {path}")
+            return original_remove(path)
+        
+        with patch('os.remove', side_effect=delayed_remove):
+            # 不应该抛出异常
+            cleaned = cleaner_no_auto_start.cleanup_sync()
+        
+        # FileNotFoundError 应该被忽略，返回 0
+        assert cleaned == 0
+    
+    def test_permission_error_handled(self, cleaner_no_auto_start, temp_input_dir):
+        """测试权限错误被处理"""
+        create_test_file(temp_input_dir, "old.png", age_seconds=5)
+        
+        with patch('os.remove', side_effect=PermissionError("Access denied")):
+            # 不应该抛出异常
+            cleaned = cleaner_no_auto_start.cleanup_sync()
+        
+        assert cleaned == 0
+    
+    def test_cleaner_stop(self, temp_input_dir):
+        """测试清理器停止"""
+        with patch.dict(os.environ, {"INPUT_CLEANUP_MIN_FILES": "0"}):
+            cleaner = InputCleaner(
+                input_dir=temp_input_dir,
+                cleanup_interval=1,
+                file_ttl=2,
+            )
+            
+            assert cleaner.is_running
+            
+            cleaner.stop()
+            time.sleep(0.2)
+            
+            assert not cleaner.is_running
+
+
+# ==================== 最小文件数阈值测试 ====================
+
+class TestMinFilesThreshold:
+    """测试最小文件数阈值功能"""
+    
+    def test_skip_cleanup_when_below_threshold(self, temp_input_dir):
+        """测试文件数低于阈值时跳过清理"""
+        with patch.object(InputCleaner, '_cleanup_loop'):
+            with patch.dict(os.environ, {"INPUT_CLEANUP_MIN_FILES": "10"}):
+                cleaner = InputCleaner(
+                    input_dir=temp_input_dir,
+                    cleanup_interval=1,
+                    file_ttl=2,
+                )
+                
+                # 创建 5 个过期文件（低于阈值 10）
+                for i in range(5):
+                    create_test_file(temp_input_dir, f"old_{i}.png", age_seconds=5)
+                
+                cleaned = cleaner.cleanup_sync()
+                
+                # 因为文件数 (5) < 阈值 (10)，不应该清理
+                assert cleaned == 0
+                assert len(os.listdir(temp_input_dir)) == 5, "文件数低于阈值时不应清理"
+    
+    def test_cleanup_when_above_threshold(self, temp_input_dir):
+        """测试文件数高于阈值时正常清理"""
+        with patch.object(InputCleaner, '_cleanup_loop'):
+            with patch.dict(os.environ, {"INPUT_CLEANUP_MIN_FILES": "5"}):
+                cleaner = InputCleaner(
+                    input_dir=temp_input_dir,
+                    cleanup_interval=1,
+                    file_ttl=2,
+                )
+                
+                # 创建 10 个过期文件（高于阈值 5）
+                for i in range(10):
+                    create_test_file(temp_input_dir, f"old_{i}.png", age_seconds=5)
+                
+                cleaned = cleaner.cleanup_sync()
+                
+                # 因为文件数 (10) >= 阈值 (5)，应该清理所有过期文件
+                assert cleaned == 10
+                assert len(os.listdir(temp_input_dir)) == 0
+    
+    def test_cleanup_at_exact_threshold(self, temp_input_dir):
+        """测试文件数正好等于阈值时正常清理"""
+        with patch.object(InputCleaner, '_cleanup_loop'):
+            with patch.dict(os.environ, {"INPUT_CLEANUP_MIN_FILES": "5"}):
+                cleaner = InputCleaner(
+                    input_dir=temp_input_dir,
+                    cleanup_interval=1,
+                    file_ttl=2,
+                )
+                
+                # 创建 5 个过期文件（等于阈值 5）
+                for i in range(5):
+                    create_test_file(temp_input_dir, f"old_{i}.png", age_seconds=5)
+                
+                cleaned = cleaner.cleanup_sync()
+                
+                # 因为文件数 (5) >= 阈值 (5)，应该清理
+                assert cleaned == 5
+    
+    def test_threshold_counts_only_files(self, temp_input_dir):
+        """测试阈值只计算文件数，不计算子目录"""
+        with patch.object(InputCleaner, '_cleanup_loop'):
+            with patch.dict(os.environ, {"INPUT_CLEANUP_MIN_FILES": "5"}):
+                cleaner = InputCleaner(
+                    input_dir=temp_input_dir,
+                    cleanup_interval=1,
+                    file_ttl=2,
+                )
+                
+                # 创建 3 个文件和 3 个子目录
+                for i in range(3):
+                    create_test_file(temp_input_dir, f"old_{i}.png", age_seconds=5)
+                    os.makedirs(os.path.join(temp_input_dir, f"subdir_{i}"))
+                
+                cleaned = cleaner.cleanup_sync()
+                
+                # 文件数 (3) < 阈值 (5)，不应清理（子目录不计入）
+                assert cleaned == 0
+                assert len([f for f in os.listdir(temp_input_dir) if os.path.isfile(os.path.join(temp_input_dir, f))]) == 3
+    
+    def test_threshold_with_mixed_files(self, temp_input_dir):
+        """测试阈值与混合文件（过期和新文件）"""
+        with patch.object(InputCleaner, '_cleanup_loop'):
+            with patch.dict(os.environ, {"INPUT_CLEANUP_MIN_FILES": "5"}):
+                cleaner = InputCleaner(
+                    input_dir=temp_input_dir,
+                    cleanup_interval=1,
+                    file_ttl=2,
+                )
+                
+                # 创建 3 个过期文件和 3 个新文件（总数 6，高于阈值 5）
+                for i in range(3):
+                    create_test_file(temp_input_dir, f"old_{i}.png", age_seconds=5)
+                for i in range(3):
+                    create_test_file(temp_input_dir, f"new_{i}.png", age_seconds=0)
+                
+                cleaned = cleaner.cleanup_sync()
+                
+                # 文件数 (6) >= 阈值 (5)，应该清理过期文件
+                assert cleaned == 3
+                assert len(os.listdir(temp_input_dir)) == 3  # 只剩新文件
+
+
+# ==================== 属性测试 ====================
+
+class TestProperties:
+    """测试属性访问"""
+    
+    def test_properties(self, cleaner_no_auto_start, temp_input_dir):
+        """测试属性返回正确的值"""
+        assert cleaner_no_auto_start.input_dir == temp_input_dir
+        assert cleaner_no_auto_start.cleanup_interval == 1
+        assert cleaner_no_auto_start.file_ttl == 2
+
+
+# ==================== 集成测试 ====================
+
+class TestIntegration:
+    """集成测试 - 模拟真实使用场景"""
+    
+    def test_continuous_file_generation_and_cleanup(self, temp_input_dir):
+        """
+        模拟持续生成文件并清理的场景
+        
+        场景：每 0.2 秒生成一个文件，TTL 为 1 秒，清理间隔 0.5 秒
+        期望：最终目录中只保留最近 1 秒内的文件（约 5 个）
+        """
+        with patch.dict(os.environ, {"INPUT_CLEANUP_MIN_FILES": "0"}):
+            cleaner = InputCleaner(
+                input_dir=temp_input_dir,
+                cleanup_interval=0.5,  # 0.5秒清理间隔
+                file_ttl=1,  # 1秒过期
+            )
+            
+            try:
+                # 持续生成文件 2 秒
+                for i in range(10):
+                    create_test_file(temp_input_dir, f"file_{i}.png")
+                    cleaner.wake()
+                    time.sleep(0.2)
+                
+                # 等待最后一次清理
+                time.sleep(1)
+                cleaner.wake()
+                time.sleep(0.5)
+                
+                # 检查剩余文件数量（应该只有最近 1 秒内的文件）
+                remaining_files = os.listdir(temp_input_dir)
+                
+                # 由于 TTL 是 1 秒，生成间隔 0.2 秒，最多保留 5 个左右的文件
+                assert len(remaining_files) <= 6, f"剩余文件数 {len(remaining_files)} 超过预期"
+                
+            finally:
+                cleaner.stop()
+
+
+# ==================== 性能测试 ====================
+
+class TestPerformance:
+    """性能测试 - 大量文件场景"""
+    
+    def test_cleanup_10000_files_mixed(self, temp_input_dir):
+        """
+        测试大量文件清理性能
+        
+        场景：10000 个文件，50% 过期，50% 未过期
+        期望：清理耗时在合理范围内（< 10 秒）
+        """
+        with patch.object(InputCleaner, '_cleanup_loop'):
+            with patch.dict(os.environ, {"INPUT_CLEANUP_MIN_FILES": "0"}):
+                cleaner = InputCleaner(
+                    input_dir=temp_input_dir,
+                    cleanup_interval=1,
+                    file_ttl=2,
+                )
+                
+                total_files = 10000
+                expired_count = total_files // 2
+                fresh_count = total_files - expired_count
+                
+                print(f"\n创建 {total_files} 个测试文件...")
+                start_create = time.time()
+                
+                # 创建过期文件
+                for i in range(expired_count):
+                    create_test_file(temp_input_dir, f"expired_{i}.png", age_seconds=5)
+                
+                # 创建新文件
+                for i in range(fresh_count):
+                    create_test_file(temp_input_dir, f"fresh_{i}.png", age_seconds=0)
+                
+                create_elapsed = time.time() - start_create
+                print(f"文件创建耗时: {create_elapsed:.2f}s")
+                
+                # 验证文件数量
+                actual_files = len(os.listdir(temp_input_dir))
+                assert actual_files == total_files, f"文件数量不匹配: {actual_files} != {total_files}"
+                
+                # 执行清理并计时
+                print(f"开始清理...")
+                start_cleanup = time.time()
+                cleaned = cleaner.cleanup_sync()
+                cleanup_elapsed = time.time() - start_cleanup
+                
+                print(f"清理完成: 删除 {cleaned} 个文件，耗时 {cleanup_elapsed:.2f}s")
+                
+                # 验证结果
+                assert cleaned == expired_count, f"清理数量不匹配: {cleaned} != {expired_count}"
+                
+                remaining_files = len(os.listdir(temp_input_dir))
+                assert remaining_files == fresh_count, f"剩余文件数不匹配: {remaining_files} != {fresh_count}"
+                
+                # 性能断言：清理 10000 个文件应该在 10 秒内完成
+                assert cleanup_elapsed < 10, f"清理耗时过长: {cleanup_elapsed:.2f}s > 10s"
+                
+                print(f"性能指标: {cleaned / cleanup_elapsed:.0f} 文件/秒")
+    
+    def test_cleanup_10000_files_all_expired(self, temp_input_dir):
+        """
+        测试大量过期文件清理性能
+        
+        场景：10000 个文件，全部过期
+        """
+        with patch.object(InputCleaner, '_cleanup_loop'):
+            with patch.dict(os.environ, {"INPUT_CLEANUP_MIN_FILES": "0"}):
+                cleaner = InputCleaner(
+                    input_dir=temp_input_dir,
+                    cleanup_interval=1,
+                    file_ttl=2,
+                )
+                
+                total_files = 10000
+                
+                print(f"\n创建 {total_files} 个过期文件...")
+                start_create = time.time()
+                
+                for i in range(total_files):
+                    create_test_file(temp_input_dir, f"expired_{i}.png", age_seconds=5)
+                
+                create_elapsed = time.time() - start_create
+                print(f"文件创建耗时: {create_elapsed:.2f}s")
+                
+                # 执行清理并计时
+                print(f"开始清理...")
+                start_cleanup = time.time()
+                cleaned = cleaner.cleanup_sync()
+                cleanup_elapsed = time.time() - start_cleanup
+                
+                print(f"清理完成: 删除 {cleaned} 个文件，耗时 {cleanup_elapsed:.2f}s")
+                
+                # 验证结果
+                assert cleaned == total_files
+                assert len(os.listdir(temp_input_dir)) == 0
+                
+                # 性能断言
+                assert cleanup_elapsed < 10, f"清理耗时过长: {cleanup_elapsed:.2f}s > 10s"
+                
+                print(f"性能指标: {cleaned / cleanup_elapsed:.0f} 文件/秒")
+    
+    def test_cleanup_10000_files_none_expired(self, temp_input_dir):
+        """
+        测试大量未过期文件的扫描性能
+        
+        场景：10000 个文件，全部未过期（只扫描不删除）
+        注意：TTL 设为 60 秒，确保文件创建期间不会过期
+        """
+        with patch.object(InputCleaner, '_cleanup_loop'):
+            with patch.dict(os.environ, {"INPUT_CLEANUP_MIN_FILES": "0"}):
+                cleaner = InputCleaner(
+                    input_dir=temp_input_dir,
+                    cleanup_interval=1,
+                    file_ttl=60,  # 60秒 TTL，确保创建期间不过期
+                )
+                
+                total_files = 10000
+                
+                print(f"\n创建 {total_files} 个新文件...")
+                start_create = time.time()
+                
+                for i in range(total_files):
+                    create_test_file(temp_input_dir, f"fresh_{i}.png", age_seconds=0)
+                
+                create_elapsed = time.time() - start_create
+                print(f"文件创建耗时: {create_elapsed:.2f}s")
+                
+                # 执行清理并计时（应该只扫描，不删除）
+                print(f"开始扫描...")
+                start_cleanup = time.time()
+                cleaned = cleaner.cleanup_sync()
+                cleanup_elapsed = time.time() - start_cleanup
+                
+                print(f"扫描完成: 删除 {cleaned} 个文件，耗时 {cleanup_elapsed:.2f}s")
+                
+                # 验证结果
+                assert cleaned == 0, "不应删除任何文件"
+                assert len(os.listdir(temp_input_dir)) == total_files
+                
+                # 性能断言：纯扫描应该更快
+                assert cleanup_elapsed < 5, f"扫描耗时过长: {cleanup_elapsed:.2f}s > 5s"
+                
+                print(f"性能指标: {total_files / cleanup_elapsed:.0f} 文件/秒 (扫描)")
+
+
+# ==================== 模块级函数测试 ====================
+
+class TestModuleFunctions:
+    """测试模块级便捷函数"""
+    
+    def test_wake_function_when_disabled(self):
+        """测试清理器禁用时 wake() 不报错"""
+        from services.serverlessapi import input_cleaner
+        
+        # 保存原始实例
+        original_instance = input_cleaner._cleaner_instance
+        
+        try:
+            # 设置为 None 模拟禁用状态
+            input_cleaner._cleaner_instance = None
+            
+            # 不应该抛出异常
+            input_cleaner.wake()
+            
+        finally:
+            # 恢复原始实例
+            input_cleaner._cleaner_instance = original_instance
+    
+    def test_get_cleaner_returns_instance(self):
+        """测试 get_cleaner() 返回实例"""
+        from services.serverlessapi.input_cleaner import get_cleaner, _cleaner_instance
+        
+        result = get_cleaner()
+        assert result is _cleaner_instance
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])
+


### PR DESCRIPTION
- 新增 MNT_INPUT_DIR 常量，支持通过环境变量配置共享存储输入目录
- 整合 COMFYUI_MODE 配置，根据 CPU/GPU 模式设置 INPUT_DIR 和启动命令
- LoadImage 等节点支持自动从 MNT_INPUT_DIR 复制文件到 INPUT_DIR
- 使用 file_ops.copy 替代 shutil.copy2

issue: https://aliyuque.antfin.com/lnpq52/cc8sut/slcnbzw0t7q9snbb