### PR TITLE
优化健康检查机制：移除 HTTP 检查，改用轻量级端口检查

### DIFF
--- a/src/code/agent/services/process/comfyui_process_manager.py
+++ b/src/code/agent/services/process/comfyui_process_manager.py
@@ -3,8 +3,6 @@ import socket
 import subprocess
 from datetime import datetime
 
-import requests
-
 import constants
 from services.process.process_manager import ProcessManager
 from utils.logger import log
@@ -13,13 +11,12 @@ from utils.logger import log
 class ComfyUIProcessManager(ProcessManager):
     """ComfyUI 进程管理器"""
     
-    HEALTH_CHECK_TIMEOUT = 10  # 健康检查超时时间（秒）
     SOCKET_TIMEOUT = 1  # Socket 连接超时时间（秒）
     MAX_CONSECUTIVE_FAILURES = 3  # 连续失败次数阈值，达到后触发重启
     
     def __init__(self):
         super().__init__()
-        self._consecutive_http_failures = 0  # HTTP 健康检查连续失败计数
+        self._consecutive_failures = 0  # 端口检查连续失败计数
 
     def _is_ready(self) -> bool:
         """
@@ -53,36 +50,16 @@ class ComfyUIProcessManager(ProcessManager):
         # poll() 返回 None 表示进程仍在运行，返回退出码表示进程已结束
         return self.process.poll() is None
 
-    def _check_http_health(self) -> bool:
-        """
-        通过发送 HTTP GET 请求检查后端服务是否响应正常
-        
-        Returns:
-            bool: 如果在超时时间内收到正常响应返回 True，否则返回 False
-        """
-        try:
-            response = requests.get(
-                f'http://127.0.0.1:{constants.BACKEND_PROCESS_PORT}',
-                timeout=self.HEALTH_CHECK_TIMEOUT
-            )
-            return response.status_code == 200
-        except requests.Timeout:
-            log("DEBUG", "Health check timed out")
-            return False
-        except requests.ConnectionError:
-            log("DEBUG", "Health check connection refused")
-            return False
-        except requests.RequestException as e:
-            log("DEBUG", f"Health check failed: {e}")
-            return False
-
     def _is_alive(self) -> bool:
         """
         检查 ComfyUI 进程是否存活
 
         健康检查策略（两级判断机制）：
-        1. 进程存在性检查：如果进程不存在（如被 OOM Killed），直接判定为不存活
-        2. HTTP 健康检查：如果进程存在但 HTTP 检查连续失败 3 次，判定为不存活
+        1. 进程存在性检查：如果进程不存在（如被 OOM Killed），立即判定为不存活
+        2. 端口监听检查：如果进程存在但端口连续失败 3 次，判定为不存活
+        
+        注意：不使用 HTTP 请求检查，因为 ComfyUI 繁忙时会超时导致误判。
+              使用轻量级的 TCP 端口连接检查，即使繁忙也能快速响应。
 
         特殊情况：
         - 主动重启期间：跳过健康检查，避免误判为崩溃
@@ -100,30 +77,31 @@ class ComfyUIProcessManager(ProcessManager):
         if ManagementService().status == BackendStatus.REBOOTING:
             return True
 
-        # 第一级检查：进程是否存在
+        # 第一级检查：进程是否存在（快速检测 OOM、crash 等情况）
         if not self._is_process_running():
             exit_code = self.process.returncode if self.process else "unknown"
             log("WARNING", f"ComfyUI process is not running (exit code: {exit_code}), will trigger restart")
-            self._consecutive_http_failures = 0  # 重置计数器
+            self._consecutive_failures = 0  # 重置计数器
             return False
 
-        # 第二级检查：HTTP 健康检查
-        if self._check_http_health():
-            # 健康检查通过，重置连续失败计数
-            if self._consecutive_http_failures > 0:
-                log("DEBUG", f"Health check recovered after {self._consecutive_http_failures} failures")
-            self._consecutive_http_failures = 0
+        # 第二级检查：端口是否可连接（检测服务可用性，带容错机制）
+        if self._is_ready():
+            # 端口检查通过，重置连续失败计数
+            if self._consecutive_failures > 0:
+                log("DEBUG", f"Port check recovered after {self._consecutive_failures} failures")
+            self._consecutive_failures = 0
             return True
         else:
-            # 健康检查失败，累计连续失败次数
-            self._consecutive_http_failures += 1
+            # 端口检查失败，累计连续失败次数
+            self._consecutive_failures += 1
             
-            if self._consecutive_http_failures >= self.MAX_CONSECUTIVE_FAILURES:
-                log("WARNING", f"HTTP health check failed {self.MAX_CONSECUTIVE_FAILURES} consecutive times, will trigger restart")
-                self._consecutive_http_failures = 0  # 重置计数器，避免重启后立即再次触发
+            if self._consecutive_failures >= self.MAX_CONSECUTIVE_FAILURES:
+                log("WARNING", f"Port {constants.BACKEND_PROCESS_PORT} check failed {self.MAX_CONSECUTIVE_FAILURES} consecutive times, will trigger restart")
+                self._consecutive_failures = 0  # 重置计数器，避免重启后立即再次触发
                 return False
             
             # 未达到阈值，暂时认为存活，等待下次检查
+            log("DEBUG", f"Port check failed ({self._consecutive_failures}/{self.MAX_CONSECUTIVE_FAILURES})")
             return True
 
     def _on_process_died(self):
@@ -142,9 +120,9 @@ class ComfyUIProcessManager(ProcessManager):
         self._do_restart()
 
     def _save_dmesg_log(self):
-        """保存 dmesg 日志到 MNT_DIR 下的 crash_reports 目录"""
+        """保存 dmesg 日志到 MNT_DIR 下的 .funart/crash_reports 目录"""
         try:
-            log_dir = os.path.join(constants.MNT_DIR, 'crash_reports')
+            log_dir = os.path.join(constants.MNT_DIR, '.funart', 'crash_reports')
             os.makedirs(log_dir, exist_ok=True)
             
             timestamp = datetime.now().strftime('%Y%m%d-%H%M%S')
@@ -177,8 +155,13 @@ class ComfyUIProcessManager(ProcessManager):
         try:
             service._transition_to(BackendStatus.REBOOTING, Action.REBOOT)
             
-            # 清理旧进程资源，防止僵尸进程
-            self._cleanup_dead_process()
+            # 先停止旧进程（如果还在运行），释放端口和资源
+            if self._is_process_running():
+                log("INFO", "Stopping old ComfyUI process before restart")
+                self.stop()
+            else:
+                # 只清理僵尸进程资源
+                self._cleanup_dead_process()
             
             # 重新启动 ComfyUI 进程
             self.start(constants.BOOT_CMD)

--- a/src/code/agent/test/unit/services/comfyui_process_manager_test.py
+++ b/src/code/agent/test/unit/services/comfyui_process_manager_test.py
@@ -25,10 +25,8 @@ ComfyUI Process Manager 测试用例
    - test_wait_until_ready_timeout: 启动超时处理
 
 2. 健康检查测试：
-   - test_http_health_check_consecutive_failures: HTTP 连续失败检测
-   - test_http_health_check_recovery: HTTP 健康检查恢复
-   - test_http_health_check_timeout: HTTP 响应超时
-   - test_check_http_health_method: HTTP 健康检查方法
+   - test_port_check_consecutive_failures: 端口检查连续失败检测
+   - test_port_check_recovery: 端口检查恢复
 
 3. 进程状态测试：
    - test_process_crash_detection: 进程崩溃检测
@@ -46,9 +44,7 @@ ComfyUI Process Manager 测试用例
 4. 确保端口 8188 未被占用：lsof -i :8188
 
 Mock 进程说明：
-- mock_comfyui_process.py: 健康的 HTTP 服务器（返回 200）
-- mock_unhealthy_process.py: 不健康的服务器（返回 500）
-- mock_slow_response_process.py: 响应缓慢的服务器（超时测试）
+- mock_comfyui_process.py: 健康的 HTTP 服务器（监听端口 8188）
 - mock_crash_process.py: 启动后立即崩溃的进程（OOM 模拟）
 
 故障排查：
@@ -217,20 +213,18 @@ def test_wait_until_ready_timeout(process_manager):
     script_path.unlink()
 
 
-def test_http_health_check_consecutive_failures():
+def test_port_check_consecutive_failures():
     """
-    测试 HTTP 健康检查连续失败达到阈值（MAX_CONSECUTIVE_FAILURES = 3）
+    测试端口检查连续失败达到阈值（MAX_CONSECUTIVE_FAILURES = 3）
     
-    场景：进程运行正常（端口监听），但 HTTP 返回非 200 状态码
+    场景：进程运行正常，但端口不可连接（模拟服务挂起）
     预期：连续失败 3 次后，_is_alive() 返回 False
     """
-    script_path = Path(__file__).parent / "mock_unhealthy_process.py"
-    
-    # 不使用 fixture，避免 mock _is_alive
     mgr = ComfyUIProcessManager()
+    script_path = Path(__file__).parent / "mock_comfyui_process.py"
     
     try:
-        # 启动不健康的进程（返回 500）
+        # 启动进程
         command = ['python3', str(script_path)]
         mgr.start(command)
         
@@ -243,20 +237,22 @@ def test_http_health_check_consecutive_failures():
         
         assert mgr._is_ready() is True
         
-        # 第一次检查：HTTP 失败，但未达到阈值，仍然存活
-        result1 = mgr._is_alive()
-        assert result1 is True
-        assert mgr._consecutive_http_failures == 1
-        
-        # 第二次检查：HTTP 失败，但未达到阈值，仍然存活
-        result2 = mgr._is_alive()
-        assert result2 is True
-        assert mgr._consecutive_http_failures == 2
-        
-        # 第三次检查：HTTP 失败，达到阈值，判定为不存活
-        result3 = mgr._is_alive()
-        assert result3 is False
-        assert mgr._consecutive_http_failures == 0  # 计数器被重置
+        # 模拟端口检查失败（通过 mock _is_ready）
+        with patch.object(mgr, '_is_ready', return_value=False):
+            # 第一次检查：端口失败，但未达到阈值，仍然存活
+            result1 = mgr._is_alive()
+            assert result1 is True
+            assert mgr._consecutive_failures == 1
+            
+            # 第二次检查：端口失败，但未达到阈值，仍然存活
+            result2 = mgr._is_alive()
+            assert result2 is True
+            assert mgr._consecutive_failures == 2
+            
+            # 第三次检查：端口失败，达到阈值，判定为不存活
+            result3 = mgr._is_alive()
+            assert result3 is False
+            assert mgr._consecutive_failures == 0  # 计数器被重置
         
     finally:
         if mgr.process:
@@ -264,71 +260,18 @@ def test_http_health_check_consecutive_failures():
             time.sleep(1)
 
 
-def test_http_health_check_recovery():
+def test_port_check_recovery():
     """
-    测试 HTTP 健康检查失败后恢复
+    测试端口检查失败后恢复
     
-    场景：HTTP 健康检查失败 2 次（未达到阈值），然后恢复正常
+    场景：端口检查失败 2 次（未达到阈值），然后恢复正常
     预期：恢复后计数器被重置为 0
     """
     mgr = ComfyUIProcessManager()
-    script_unhealthy = Path(__file__).parent / "mock_unhealthy_process.py"
-    script_healthy = Path(__file__).parent / "mock_comfyui_process.py"
+    script_path = Path(__file__).parent / "mock_comfyui_process.py"
     
     try:
-        # 启动不健康的进程
-        command = ['python3', str(script_unhealthy)]
-        mgr.start(command)
-        
-        # 手动等待端口就绪，不启动健康检查线程
-        start_time = time.time()
-        while time.time() - start_time < 10:
-            if mgr._is_ready():
-                break
-            time.sleep(1)
-        
-        # 模拟 2 次失败
-        assert mgr._is_alive() is True
-        assert mgr._consecutive_http_failures == 1
-        assert mgr._is_alive() is True
-        assert mgr._consecutive_http_failures == 2
-        
-        # 停止不健康的进程，启动健康的进程
-        mgr.stop()
-        time.sleep(1)
-        
-        command = ['python3', str(script_healthy)]
-        mgr.start(command)
-        
-        # 手动等待端口就绪
-        start_time = time.time()
-        while time.time() - start_time < 10:
-            if mgr._is_ready():
-                break
-            time.sleep(1)
-        
-        # 健康检查应该通过，计数器重置
-        assert mgr._is_alive() is True
-        assert mgr._consecutive_http_failures == 0
-        
-    finally:
-        if mgr.process:
-            mgr.stop()
-            time.sleep(1)
-
-
-def test_http_health_check_timeout():
-    """
-    测试 HTTP 健康检查超时
-    
-    场景：进程响应缓慢，超过健康检查超时时间（10秒）
-    预期：健康检查失败，连续失败计数增加
-    """
-    mgr = ComfyUIProcessManager()
-    script_path = Path(__file__).parent / "mock_slow_response_process.py"
-    
-    try:
-        # 启动响应缓慢的进程
+        # 启动进程
         command = ['python3', str(script_path)]
         mgr.start(command)
         
@@ -339,9 +282,16 @@ def test_http_health_check_timeout():
                 break
             time.sleep(1)
         
-        # 健康检查会超时，但进程仍在运行
-        assert mgr._is_alive() is True  # 第一次失败，未达到阈值
-        assert mgr._consecutive_http_failures == 1
+        # 模拟 2 次端口检查失败
+        with patch.object(mgr, '_is_ready', return_value=False):
+            assert mgr._is_alive() is True
+            assert mgr._consecutive_failures == 1
+            assert mgr._is_alive() is True
+            assert mgr._consecutive_failures == 2
+        
+        # 端口恢复正常（移除 mock）
+        assert mgr._is_alive() is True
+        assert mgr._consecutive_failures == 0  # 计数器重置
         
     finally:
         if mgr.process:
@@ -409,52 +359,6 @@ def test_is_ready_port_check(process_manager):
     
     # 进程停止后，端口不再监听
     assert process_manager._is_ready() is False
-
-
-def test_check_http_health_method():
-    """
-    测试 _check_http_health() 方法
-    
-    验证该方法能够正确判断 HTTP 服务是否健康
-    """
-    mgr = ComfyUIProcessManager()
-    script_healthy = Path(__file__).parent / "mock_comfyui_process.py"
-    script_unhealthy = Path(__file__).parent / "mock_unhealthy_process.py"
-    
-    try:
-        # 测试健康的服务器
-        command = ['python3', str(script_healthy)]
-        mgr.start(command)
-        
-        # 手动等待端口就绪
-        start_time = time.time()
-        while time.time() - start_time < 10:
-            if mgr._is_ready():
-                break
-            time.sleep(1)
-        
-        assert mgr._check_http_health() is True
-        
-        mgr.stop()
-        time.sleep(1)
-        
-        # 测试不健康的服务器
-        command = ['python3', str(script_unhealthy)]
-        mgr.start(command)
-        
-        # 手动等待端口就绪
-        start_time = time.time()
-        while time.time() - start_time < 10:
-            if mgr._is_ready():
-                break
-            time.sleep(1)
-        
-        assert mgr._check_http_health() is False
-        
-    finally:
-        if mgr.process:
-            mgr.stop()
-            time.sleep(1)
 
 
 @patch('constants.COMFYUI_MODE', 'cpu')


### PR DESCRIPTION
主要改动：
1. 移除容易误判的 HTTP 健康检查（在 ComfyUI 繁忙时会超时）
2. 改用轻量级的 TCP 端口连接检查（_is_ready）
3. 修复重启时 hang 住的问题：_do_restart 现在会主动停止旧进程
4. 将 crash_reports 目录移至 .funart/crash_reports
5. 更新相关单元测试，移除 HTTP 检查测试，新增端口检查测试

改进效果：
- 避免因 ComfyUI 繁忙导致的误判重启
- 重启时不再 hang 在 wait_until_ready（最多 900 秒）
- 健康检查更快速、更可靠