### PR TITLE
chore(DevsInnerApis): 提取 pip 兜底源配置为可配置常量并复用。

### DIFF
--- a/src/code/agent/constants.py
+++ b/src/code/agent/constants.py
@@ -34,6 +34,9 @@ AUTO_INSTALL_NODES = os.getenv('AUTO_INSTALL_NODES', '')
 
 # 第一轮分批安装每批的包数，可通过环境变量 INSTALL_BATCH_SIZE 覆盖
 INSTALL_BATCH_SIZE = int(os.getenv('INSTALL_BATCH_SIZE', '20'))
+# 自动安装缺失依赖时，兜底安装使用的 pip 源，
+# 避免 tsinghua/ustc 源 403 等问题干扰关键安装，默认使用阿里源
+PIP_FALLBACK_INDEX_URL = os.getenv('PIP_FALLBACK_INDEX_URL', 'https://mirrors.aliyun.com/pypi/simple/')
 BUILTIN_NODES_DIR = os.getenv("BUILTIN_NODES_DIR", "/root/built-in/custom_nodes")
 BUILTIN_DELTA_NODES_DIR = os.getenv("BUILTIN_DELTA_NODES_DIR", "/root/built-in/custom_nodes_delta")
 SNAPSHOT_DIR = MNT_DIR + '/snapshots'

--- a/src/code/agent/services/pip/pip_installer.py
+++ b/src/code/agent/services/pip/pip_installer.py
@@ -8,9 +8,6 @@ import constants
 from utils import file_ops
 from services.pip.models import InstallRecord, DependencyInstallRecord, DependencyInfo
 from services.pip.version_resolver import resolve_version_conflict
-# 逐个安装（fallback 轮）使用的 pip 源：仅 aliyun 源
-# 通过环境变量覆盖 pip.conf，避免 tsinghua/ustc 源问题干扰兜底安装
-_FALLBACK_INDEX_URL = "https://mirrors.aliyun.com/pypi/simple/"
 
 
 class PIPInstaller:
@@ -393,9 +390,7 @@ class PIPInstaller:
         使用精简源配置（仅 aliyun 源），通过环境变量覆盖 pip.conf，
         避免 tsinghua/ustc 镜像覆盖不全时干扰兜底安装。
         """
-        env = self._get_pip_install_env()
-        env["PIP_INDEX_URL"] = _FALLBACK_INDEX_URL
-        env.pop("PIP_EXTRA_INDEX_URL", None)
+        env = self._get_fallback_pip_env()
 
         total = len(deps)
         for idx, dep in enumerate(deps):
@@ -475,7 +470,7 @@ class PIPInstaller:
         cmd = self._construct_pip_cmd(["install", "-r", requirements_path])
 
         try:
-            result = subprocess.run(cmd, timeout=remaining, env=self._get_pip_install_env())
+            result = subprocess.run(cmd, timeout=remaining, env=self._get_fallback_pip_env())
             if result.returncode == 0:
                 print("[Installer] ## Step 4: ComfyUI requirements reinstalled successfully")
             else:
@@ -614,6 +609,13 @@ class PIPInstaller:
             new_env.pop(proxy_var, None)
 
         return new_env
+
+    def _get_fallback_pip_env(self):
+        """使用 fallback 源的 pip 环境，确保不受 pip.conf 中其他镜像源影响"""
+        env = self._get_pip_install_env()
+        env["PIP_INDEX_URL"] = constants.PIP_FALLBACK_INDEX_URL
+        env.pop("PIP_EXTRA_INDEX_URL", None)
+        return env
 
     def _get_possible_nodes(self, custom_node_path):
         nodes = os.listdir(custom_node_path)

--- a/src/code/agent/test/unit/services/pip/batch_install_test.py
+++ b/src/code/agent/test/unit/services/pip/batch_install_test.py
@@ -42,6 +42,7 @@ def _make_installer():
          patch("services.pip.pip_installer.constants") as c:
         c.COMFYUI_DIR = "/tmp/fake"
         c.VENV_EXECUTABLE = "/fake/python"
+        c.PIP_FALLBACK_INDEX_URL = "https://mirrors.aliyun.com/pypi/simple/"
         return PIPInstaller()
 
 

--- a/src/code/agent/test/unit/services/pip/pip_installer_test.py
+++ b/src/code/agent/test/unit/services/pip/pip_installer_test.py
@@ -32,6 +32,7 @@ class _Base(unittest.TestCase):
         self.mock_constants = self._patch_constants.start()
         self.mock_constants.COMFYUI_DIR = self.comfyui_dir
         self.mock_constants.VENV_EXECUTABLE = "/fake/venv/bin/python"
+        self.mock_constants.PIP_FALLBACK_INDEX_URL = "https://mirrors.aliyun.com/pypi/simple/"
 
     def tearDown(self):
         self._patch_constants.stop()
@@ -569,6 +570,33 @@ class TestEnvironmentHandling(_Base):
         self.assertNotIn("http_proxy", env)
         self.assertIn("PATH", env)
 
+    def test_fallback_pip_env_sets_index_url(self):
+        """fallback env 应设置 PIP_INDEX_URL 为 constants.PIP_FALLBACK_INDEX_URL"""
+        with patch("os.environ.copy", return_value={"PATH": "/usr/bin"}):
+            env = self.inst._get_fallback_pip_env()
+        self.assertEqual(env["PIP_INDEX_URL"], "https://mirrors.aliyun.com/pypi/simple/")
+
+    def test_fallback_pip_env_removes_extra_index_url(self):
+        """fallback env 应移除 PIP_EXTRA_INDEX_URL，避免其他源干扰"""
+        base = {"PATH": "/usr/bin", "PIP_EXTRA_INDEX_URL": "https://other.mirror/simple/"}
+        with patch("os.environ.copy", return_value=base.copy()):
+            env = self.inst._get_fallback_pip_env()
+        self.assertNotIn("PIP_EXTRA_INDEX_URL", env)
+
+    def test_fallback_pip_env_removes_proxy(self):
+        """fallback env 继承 _get_pip_install_env 的代理清除逻辑"""
+        with patch("os.environ.copy", return_value=self._base_env.copy()):
+            env = self.inst._get_fallback_pip_env()
+        for var in ["http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"]:
+            self.assertNotIn(var, env)
+
+    def test_fallback_pip_env_keeps_non_proxy_vars(self):
+        """fallback env 保留非代理环境变量"""
+        with patch("os.environ.copy", return_value=self._base_env.copy()):
+            env = self.inst._get_fallback_pip_env()
+        self.assertIn("PATH", env)
+        self.assertIn("HOME", env)
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # 11. _do_install_script
@@ -912,6 +940,22 @@ class TestReinstallComfyuiRequirements(_Base):
         self.assertNotIn("http_proxy", used_env)
         self.assertNotIn("HTTPS_PROXY", used_env)
         self.assertIn("PATH", used_env)
+
+    def test_uses_fallback_index_url(self):
+        """Step 4 应使用 fallback 源，不受 pip.conf 中其他镜像源影响"""
+        self._make_comfyui_requirements()
+        mock_result = subprocess.CompletedProcess(args=[], returncode=0)
+        base_env = {
+            "PATH": "/usr/bin",
+            "PIP_EXTRA_INDEX_URL": "https://some.other.mirror/simple/",
+        }
+        with patch("subprocess.run", return_value=mock_result) as mock_run, \
+             patch("os.environ.copy", return_value=base_env.copy()), \
+             patch("builtins.print"):
+            self.inst._reinstall_comfyui_requirements(timeout=600, start_time=time.time())
+        used_env = mock_run.call_args[1]["env"]
+        self.assertEqual(used_env["PIP_INDEX_URL"], "https://mirrors.aliyun.com/pypi/simple/")
+        self.assertNotIn("PIP_EXTRA_INDEX_URL", used_env)
 
     def test_remaining_timeout_passed_to_subprocess(self):
         """subprocess.run 的 timeout 参数应等于剩余时间（总超时 - 已耗时）"""


### PR DESCRIPTION
- 新增 PIP_FALLBACK_INDEX_URL 常量，支持通过环境变量覆盖兜底 pip 源；
- 将兜底源环境构造逻辑提取为 _get_fallback_pip_env() 方法，在逐个安装和 requirements 重装中复用；
- 补充 _get_fallback_pip_env 及 _reinstall_comfyui_requirements 使用 fallback 源的单元测试。

Co-developed-by: Cursor <noreply@alibaba-inc.com>
Made-with: Cursor