### PR TITLE
fix(agent): 修复 fallback pip 环境未完全隔离 pip.conf 的问题。

### DIFF
--- a/src/code/agent/Dockerfile
+++ b/src/code/agent/Dockerfile
@@ -6,9 +6,9 @@ FROM python:3.10.16-slim
 WORKDIR /root
 
 RUN --mount=type=cache,target=/var/cache/apt \
-    # 本地构建时可取消注释以使用阿里云镜像源加速
-    # sed -i 's@deb.debian.org@mirrors.aliyun.com@g' /etc/apt/sources.list.d/debian.sources 2>/dev/null || \
-    # sed -i 's@deb.debian.org@mirrors.aliyun.com@g' /etc/apt/sources.list && \
+    # 本地构建时需使用阿里镜像源加速
+    sed -i 's@deb.debian.org@mirrors.aliyun.com@g' /etc/apt/sources.list.d/debian.sources 2>/dev/null || \
+    sed -i 's@deb.debian.org@mirrors.aliyun.com@g' /etc/apt/sources.list && \
     apt update && \
     apt install -y \
     git curl wget jq ffmpeg gcc g++ build-essential libgl1 libglib2.0-0 iputils-ping \
@@ -45,6 +45,13 @@ RUN mkdir ~/.rembg && \
     cd ~/.rembg && \
     wget https://huggingface.co/tomjackson2023/rembg/resolve/main/u2net.onnx
 
+# 从 comfyui 镜像拷贝内置插件到 built-in 目录
+COPY --from=comfyui_source /root/built-in/custom_nodes /root/built-in/custom_nodes
+
+# 写入内置插件版本号，供启动时版本检查使用
+# 版本号需随内置插件列表的实质性变化（增删插件、升级版本）而更新
+RUN echo "1.6.5" > /root/built-in/version.txt
+
 ENV WORK_DIR='/root'
 ENV COMFYUI_DIR="${WORK_DIR}/comfyui"
 ENV SD_DIR="${WORK_DIR}/stable-diffusion-webui"
@@ -72,13 +79,6 @@ RUN mkdir -p ~/.pip \
 
 # 设置 GitHub 代理监控脚本执行权限
 RUN chmod +x ${AGENT_DIR}/services/proxy/github-proxy-monitor.sh
-
-# 从 comfyui 镜像拷贝内置插件到 built-in 目录
-COPY --from=comfyui_source /root/comfyui/custom_nodes /root/built-in/custom_nodes
-
-# 写入内置插件版本号，供启动时版本检查使用
-# 版本号需随内置插件列表的实质性变化（增删插件、升级版本）而更新
-RUN echo "1.6.5" > /root/built-in/version.txt
 
 RUN chmod +x ${AGENT_DIR}/entrypoint.bash
 ENTRYPOINT [ "/bin/bash", "-c", "agent/entrypoint.bash" ]

--- a/src/code/agent/constants.py
+++ b/src/code/agent/constants.py
@@ -37,6 +37,7 @@ INSTALL_BATCH_SIZE = int(os.getenv('INSTALL_BATCH_SIZE', '20'))
 # 自动安装缺失依赖时，兜底安装使用的 pip 源，
 # 避免 tsinghua/ustc 源 403 等问题干扰关键安装，默认使用阿里源
 PIP_FALLBACK_INDEX_URL = os.getenv('PIP_FALLBACK_INDEX_URL', 'https://mirrors.aliyun.com/pypi/simple/')
+PIP_TRUSTED_HOSTS = 'mirrors.aliyun.com pypi.tuna.tsinghua.edu.cn pypi.mirrors.ustc.edu.cn'
 BUILTIN_NODES_DIR = os.getenv("BUILTIN_NODES_DIR", "/root/built-in/custom_nodes")
 BUILTIN_DELTA_NODES_DIR = os.getenv("BUILTIN_DELTA_NODES_DIR", "/root/built-in/custom_nodes_delta")
 SNAPSHOT_DIR = MNT_DIR + '/snapshots'

--- a/src/code/agent/services/pip/pip_installer.py
+++ b/src/code/agent/services/pip/pip_installer.py
@@ -615,6 +615,8 @@ class PIPInstaller:
         env = self._get_pip_install_env()
         env["PIP_INDEX_URL"] = constants.PIP_FALLBACK_INDEX_URL
         env.pop("PIP_EXTRA_INDEX_URL", None)
+        env["PIP_CONFIG_FILE"] = os.devnull
+        env["PIP_TRUSTED_HOST"] = constants.PIP_TRUSTED_HOSTS
         return env
 
     def _get_possible_nodes(self, custom_node_path):

--- a/src/code/agent/test/unit/services/pip/pip_installer_test.py
+++ b/src/code/agent/test/unit/services/pip/pip_installer_test.py
@@ -33,6 +33,7 @@ class _Base(unittest.TestCase):
         self.mock_constants.COMFYUI_DIR = self.comfyui_dir
         self.mock_constants.VENV_EXECUTABLE = "/fake/venv/bin/python"
         self.mock_constants.PIP_FALLBACK_INDEX_URL = "https://mirrors.aliyun.com/pypi/simple/"
+        self.mock_constants.PIP_TRUSTED_HOSTS = "mirrors.aliyun.com pypi.tuna.tsinghua.edu.cn pypi.mirrors.ustc.edu.cn"
 
     def tearDown(self):
         self._patch_constants.stop()
@@ -583,6 +584,21 @@ class TestEnvironmentHandling(_Base):
             env = self.inst._get_fallback_pip_env()
         self.assertNotIn("PIP_EXTRA_INDEX_URL", env)
 
+    def test_fallback_pip_env_bypasses_pip_conf(self):
+        """fallback env 应将 PIP_CONFIG_FILE 设为 os.devnull，完全绕过 pip.conf"""
+        with patch("os.environ.copy", return_value={"PATH": "/usr/bin"}):
+            env = self.inst._get_fallback_pip_env()
+        self.assertEqual(env["PIP_CONFIG_FILE"], os.devnull)
+
+    def test_fallback_pip_env_sets_trusted_hosts(self):
+        """fallback env 应设置 PIP_TRUSTED_HOST，补回 pip.conf 中的信任主机"""
+        with patch("os.environ.copy", return_value={"PATH": "/usr/bin"}):
+            env = self.inst._get_fallback_pip_env()
+        self.assertEqual(
+            env["PIP_TRUSTED_HOST"],
+            "mirrors.aliyun.com pypi.tuna.tsinghua.edu.cn pypi.mirrors.ustc.edu.cn",
+        )
+
     def test_fallback_pip_env_removes_proxy(self):
         """fallback env 继承 _get_pip_install_env 的代理清除逻辑"""
         with patch("os.environ.copy", return_value=self._base_env.copy()):
@@ -956,6 +972,8 @@ class TestReinstallComfyuiRequirements(_Base):
         used_env = mock_run.call_args[1]["env"]
         self.assertEqual(used_env["PIP_INDEX_URL"], "https://mirrors.aliyun.com/pypi/simple/")
         self.assertNotIn("PIP_EXTRA_INDEX_URL", used_env)
+        self.assertEqual(used_env["PIP_CONFIG_FILE"], os.devnull)
+        self.assertIn("mirrors.aliyun.com", used_env["PIP_TRUSTED_HOST"])
 
     def test_remaining_timeout_passed_to_subprocess(self):
         """subprocess.run 的 timeout 参数应等于剩余时间（总超时 - 已耗时）"""


### PR DESCRIPTION
- pip fallback 环境通过设置 PIP_CONFIG_FILE=os.devnull 绕过 pip.conf，避免 extra-index-url 等配置泄漏；
- Dockerfile 调整构建顺序并启用阿里云镜像源加速，修正内置插件拷贝源路径；
- 补充 fallback 环境绕过 pip.conf 的单元测试。
- 绕过 pip.conf 后 trusted-host 丢失，通过 PIP_TRUSTED_HOST 环境变量补回三个镜像源主机；
- 新增 PIP_TRUSTED_HOSTS 常量，补充对应单元测试。

Co-developed-by: Cursor <noreply@alibaba-inc.com>
Made-with: Cursor